### PR TITLE
Add RxgError class that includes response body (#1)

### DIFF
--- a/lib/rxg_client.rb
+++ b/lib/rxg_client.rb
@@ -124,7 +124,7 @@ class RxgClient
         self.response_headers = response.headers
         self.parse(response.body)
       else
-        raise(response.message)
+        raise RxgError.new(response.message, response.body)
       end
     end
   end
@@ -225,4 +225,13 @@ class RxgClient
     raise exception if instance.raise_exceptions
   end
 
+end
+
+class RxgError < StandardError
+  attr_reader :response_body
+
+  def initialize(msg, response_body=nil)
+    @response_body = response_body
+    super(msg)
+  end
 end


### PR DESCRIPTION
We found that we needed access to the response body in case of errors, so this adds a StandardError subclass called RxgError that contains the response body.